### PR TITLE
주문 기능 구현

### DIFF
--- a/duckshop/src/main/java/com/devkduck/duckshop/controller/OrderController.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/controller/OrderController.java
@@ -1,0 +1,49 @@
+package com.devkduck.duckshop.controller;
+
+import com.devkduck.duckshop.dto.OrderDto;
+import com.devkduck.duckshop.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.security.Principal;
+import java.util.List;
+
+//주문관리 요청 처리
+@Controller
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping(value = "/order")
+    public @ResponseBody ResponseEntity order (@RequestBody @Valid OrderDto orderDto,
+                                               BindingResult bindingResult, Principal principal) {
+        if (bindingResult.hasErrors()) {
+            StringBuilder sb = new StringBuilder();
+            List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+            for (FieldError fieldError : fieldErrors) {
+                sb.append(fieldError.getDefaultMessage());
+            }
+            return new ResponseEntity<String>(sb.toString(), HttpStatus.BAD_REQUEST);
+        }
+
+        String email = principal.getName();
+        Long orderId;
+
+        try{
+            orderId = orderService.order(orderDto, email);
+        }
+        catch (Exception e){
+            return new ResponseEntity<String>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<Long>(orderId, HttpStatus.OK);
+    }
+
+}

--- a/duckshop/src/main/java/com/devkduck/duckshop/dto/OrderDto.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/dto/OrderDto.java
@@ -1,0 +1,19 @@
+package com.devkduck.duckshop.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderDto {
+    @NotNull(message = "상품 아이디는 필수 입력 값입니다.")
+    private Long itemId;
+
+    @Min(value = 1, message = "최소 주문 수량은 1개입니다.")
+    @Max(value = 999, message = "최대 주문 수량은 999개입니다.")
+    private int count;
+}

--- a/duckshop/src/main/java/com/devkduck/duckshop/entity/Item.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/entity/Item.java
@@ -2,6 +2,7 @@ package com.devkduck.duckshop.entity;
 
 import com.devkduck.duckshop.constant.ItemSellStatus;
 import com.devkduck.duckshop.dto.ItemFormDto;
+import com.devkduck.duckshop.exception.OutofStockException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -44,6 +45,12 @@ public class Item extends BaseEntity{
         this.itemSellStatus = itemFormDto.getItemSellStatus();
     }
 
-
+    public void removeStock(int stockNumber){
+        int restStock = this.stockNumber - stockNumber;
+        if(restStock < 0){
+            throw new OutofStockException("상품의 재고가 부족합니다. (현재 재고 수량: " + this.stockNumber + ")");
+        }
+        this.stockNumber = restStock;
+    }
 
 }

--- a/duckshop/src/main/java/com/devkduck/duckshop/entity/Order.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/entity/Order.java
@@ -33,4 +33,27 @@ public class Order extends BaseEntity{
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL
             , orphanRemoval = true, fetch = FetchType.LAZY)
     private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void addOrderItem(OrderItem orderItem){
+        orderItems.add(orderItem);
+        orderItem.setOrder(this);
+    }
+    public static Order createOrder(Member member, List<OrderItem> orderItemList){
+        Order order = new Order();
+        order.setMember(member);
+        for(OrderItem orderItem : orderItemList){
+            order.addOrderItem(orderItem);
+        }
+        order.setOrderStatus(OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+
+    public int getTotalPrice(){
+        int totalPrice = 0;
+        for(OrderItem orderItem : orderItems){
+            totalPrice += orderItem.getTotalPrice();
+        }
+        return totalPrice;
+    }
 }

--- a/duckshop/src/main/java/com/devkduck/duckshop/entity/OrderItem.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/entity/OrderItem.java
@@ -30,6 +30,19 @@ public class OrderItem extends BaseEntity{
 
     private int count;
 
+    public static OrderItem createdOrderItem(Item item, int count){
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setCount(count);
+        orderItem.setOrderPrice(item.getPrice());
+
+        item.removeStock(count);
+        return orderItem;
+    }
+
+    public int getTotalPrice(){
+        return orderPrice*count;
+    }
 
 
 }

--- a/duckshop/src/main/java/com/devkduck/duckshop/exception/OutofStockException.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/exception/OutofStockException.java
@@ -1,0 +1,9 @@
+package com.devkduck.duckshop.exception;
+
+public class OutofStockException extends RuntimeException{
+
+    //상품의 주문 수량보다 재고의 수가 적을 때 발생
+    public OutofStockException(String message){
+        super(message);
+    }
+}

--- a/duckshop/src/main/java/com/devkduck/duckshop/service/OrderService.java
+++ b/duckshop/src/main/java/com/devkduck/duckshop/service/OrderService.java
@@ -1,0 +1,44 @@
+package com.devkduck.duckshop.service;
+
+import com.devkduck.duckshop.dto.OrderDto;
+import com.devkduck.duckshop.entity.Item;
+import com.devkduck.duckshop.entity.Member;
+import com.devkduck.duckshop.entity.Order;
+import com.devkduck.duckshop.entity.OrderItem;
+import com.devkduck.duckshop.repository.ItemRepository;
+import com.devkduck.duckshop.repository.MemberRepository;
+import com.devkduck.duckshop.repository.OrderRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderService {
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
+
+    public Long order(OrderDto orderDto, String email){
+        //주문 상품 조회
+        Item item = itemRepository.findById(orderDto.getItemId())
+                .orElseThrow(EntityNotFoundException::new);
+        //로그인 이메일 이용하여 회원 정보 조회
+        Member member = memberRepository.findByEmail(email);
+
+        //주문할 상품 엔티티와 수량 이용하여 주문 상품 엔티티 생성
+        List<OrderItem> orderItemList = new ArrayList<>();
+        OrderItem orderItem = OrderItem.createdOrderItem(item,orderDto.getCount());
+        orderItemList.add(orderItem);
+
+        //회원 정보와 주문 상품 리스트 정보 이용하여 주문 엔티티 생성
+        Order order = Order.createOrder(member, orderItemList);
+        orderRepository.save(order);
+        return order.getId();
+    }
+}

--- a/duckshop/src/main/resources/templates/item/itemDtl.html
+++ b/duckshop/src/main/resources/templates/item/itemDtl.html
@@ -26,7 +26,42 @@
             var totalPrice = price*count;
             $("#totalPrice").html(totalPrice + '원');
         }
+        function order(){
+            var token = $("meta[name='_csrf']").attr("content");
+            var header = $("meta[name='_csrf_header']").attr("content");
 
+            var url = "/order";
+            var paramData = {
+                itemId: $("#itemId").val(),
+                count: $("#count").val()
+            };
+            var param = JSON.stringify(paramData);
+
+            $.ajax({
+                url :   url,
+                type:   "POST",
+                contentType: "application/json; charset=utf-8",
+                data:param,
+                beforeSend: function(xhr){
+                    xhr.setRequestHeader(header, token);
+                },
+                dataType:"json",
+                cache:  false,
+                success: function(result, status){
+                    aler("주문이 완료되었습니다.");
+                    location.href = '/';
+                },
+                error : function(jqXHR, status, error){
+                    if(jqXHR.status == '401'){
+                        alert('로그인 후 이용해주세요');
+                        location.href = '/member/login';
+                    }
+                    else{
+                        alert(jqXHR.responseText);
+                    }
+                }
+            });
+        }
 
     </script>
 </th:block>

--- a/duckshop/src/test/java/com/devkduck/duckshop/service/OrderServiceTest.java
+++ b/duckshop/src/test/java/com/devkduck/duckshop/service/OrderServiceTest.java
@@ -1,0 +1,100 @@
+package com.devkduck.duckshop.service;
+
+
+import com.devkduck.duckshop.constant.ItemSellStatus;
+import com.devkduck.duckshop.dto.OrderDto;
+import com.devkduck.duckshop.entity.Item;
+import com.devkduck.duckshop.entity.Member;
+import com.devkduck.duckshop.entity.Order;
+import com.devkduck.duckshop.entity.OrderItem;
+import com.devkduck.duckshop.repository.ItemRepository;
+import com.devkduck.duckshop.repository.MemberRepository;
+import com.devkduck.duckshop.repository.OrderRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations="classpath:application-test.properties")
+class OrderServiceTest {
+
+    @Autowired
+    private OrderService orderService;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    public Item saveItem(){
+        Item item = new Item();
+        item.setItemNm("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(ItemSellStatus.SELL);
+        item.setStockNumber(100);
+        return itemRepository.save(item);
+    }
+
+    public Member saveMember(){
+        Member member = new Member();
+        member.setEmail("test@test.com");
+        return memberRepository.save(member);
+
+    }
+
+    @Test
+    @DisplayName("주문 테스트")
+    public void order(){
+        Item item = saveItem();
+        Member member = saveMember();
+
+        OrderDto orderDto = new OrderDto();
+        orderDto.setCount(10);
+        orderDto.setItemId(item.getId());
+
+        Long orderId = orderService.order(orderDto, member.getEmail());
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        List<OrderItem> orderItems = order.getOrderItems();
+
+        int totalPrice = orderDto.getCount()*item.getPrice();
+
+        //주문 상품의 총 가격과 데이터베이스에 저장된 상품의 가격을 비교하여 성공적이어야 테스트 성공
+        assertEquals(totalPrice, order.getTotalPrice());
+    }
+
+//    @Test
+//    @DisplayName("주문 취소 테스트")
+//    public void cancelOrder(){
+//        Item item = saveItem();
+//        Member member = saveMember();
+//
+//        OrderDto orderDto = new OrderDto();
+//        orderDto.setCount(10);
+//        orderDto.setItemId(item.getId());
+//        Long orderId = orderService.order(orderDto, member.getEmail());
+//
+//        Order order = orderRepository.findById(orderId)
+//                .orElseThrow(EntityNotFoundException::new);
+//        orderService.cancelOrder(orderId);
+//
+//        assertEquals(OrderStatus.CANCEL, order.getOrderStatus());
+//        assertEquals(100, item.getStockNumber());
+//    }
+
+}


### PR DESCRIPTION
- 주문 수량보다 재고 수적을 때 발생시킬 예외 OutOfException 생성
- Item 엔티티에 주문시 재고 수량 변경 메서드 추가
- 주문할 상품과 주문 수량을 통해 OrderItem 객체 만들도록 함
- 생성한 주문 상품 객체를 이용하여 Order 객체를 만드는 메서드 생성
- 주문 로직을 수행하도록 Service 생성
- Controller :비동기 방식의 주문 api 생성
- 주문 기능 테스트 코드 작성
- itemDtl.html - csrf 값 조회 후 상품 아이디와 수량 데이터를 전달할 객체를 생성해 서버에 json 형식으로 보내도록 설정
- 주문 호출 성공시 : 주문이 완료되었습니다.
- 로그인 아닐시: 로그인 후이용해주세요
- 주문시 에러: 해당 메시지 알럿